### PR TITLE
Update anthropic module compiler plugin to support generate API calls when the anthropic import is not present in the file

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.anthropic"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.anthropic"
-version = "1.1.0"
+version = "1.1.1"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.anthropic-native"
-version = "1.1.0"
-path = "../native/build/libs/ai.anthropic-native-1.1.0.jar"
+version = "1.1.1"
+path = "../native/build/libs/ai.anthropic-native-1.1.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-anthropic-compiler-plugin"
 class = "io.ballerina.lib.ai.anthropic.AiAnthropicCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.anthropic-compiler-plugin-1.1.0.jar"
+path = "../compiler-plugin/build/libs/ai.anthropic-compiler-plugin-1.1.1-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -391,7 +391,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.anthropic"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/tests/test-generate-method-usage-in-file-without-ai-import.bal
+++ b/ballerina/tests/test-generate-method-usage-in-file-without-ai-import.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config
+function testGenerateMethodUsageInFileWithoutAiImport() returns error? {
+    Review|error result = claudeProvider->generate(`Please rate this blog out of ${"10"}.
+        Title: ${blog2.title}
+        Content: ${blog2.content}`);
+    test:assertEquals(result, review);
+}

--- a/compiler-plugin/src/main/java/io/ballerina/lib/ai/anthropic/GenerateMethodModificationTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/lib/ai/anthropic/GenerateMethodModificationTask.java
@@ -18,11 +18,10 @@
 
 package io.ballerina.lib.ai.anthropic;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.Types;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
-import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
@@ -81,6 +80,10 @@ import static io.ballerina.projects.util.ProjectConstants.EMPTY_STRING;
 class GenerateMethodModificationTask implements ModifierTask<SourceModifierContext> {
     private static final String AI_MODULE_NAME = "ai";
     private static final String BALLERINA_ORG_NAME = "ballerina";
+    private static final String ANTHROPIC_MODEL_PROVIDER_NAME = "ModelProvider";
+    private static final String ANTHROPIC_MODEL_PROVIDER_MODULE_NAME = "ai.anthropic";
+    private static final String ANTHROPIC_MODEL_PROVIDER_MODULE_VERSION = "1";
+    private static final String ANTHROPIC_MODEL_PROVIDER_MODULE_ORG = "ballerinax";
     private final AiAnthropicCodeModifier.AnalysisData analysisData;
     private final ModifierData modifierData;
 
@@ -103,12 +106,17 @@ class GenerateMethodModificationTask implements ModifierTask<SourceModifierConte
             Collection<DocumentId> documentIds = module.documentIds();
             Collection<DocumentId> testDocumentIds = module.testDocumentIds();
 
+            Types types = semanticModel.types();
+            Optional<Symbol> anthropicModelProviderSymbol =
+                    types.getTypeByName(ANTHROPIC_MODEL_PROVIDER_MODULE_ORG, ANTHROPIC_MODEL_PROVIDER_MODULE_NAME,
+                            ANTHROPIC_MODEL_PROVIDER_MODULE_VERSION, ANTHROPIC_MODEL_PROVIDER_NAME);
+
             for (DocumentId documentId : documentIds) {
-                analyzeDocument(module, documentId, semanticModel);
+                analyzeDocument(module, documentId, semanticModel, anthropicModelProviderSymbol);
             }
 
             for (DocumentId documentId : testDocumentIds) {
-                analyzeDocument(module, documentId, semanticModel);
+                analyzeDocument(module, documentId, semanticModel, anthropicModelProviderSymbol);
             }
 
             for (DocumentId documentId : documentIds) {
@@ -123,14 +131,15 @@ class GenerateMethodModificationTask implements ModifierTask<SourceModifierConte
         }
     }
 
-    private void analyzeDocument(Module module, DocumentId documentId, SemanticModel semanticModel) {
+    private void analyzeDocument(Module module, DocumentId documentId, SemanticModel semanticModel,
+                                 Optional<Symbol> anthropicModelProviderSymbol) {
         Document document = module.document(documentId);
         Node rootNode = document.syntaxTree().rootNode();
         if (!(rootNode instanceof ModulePartNode modulePartNode)) {
             return;
         }
 
-        analyzeGenerateMethod(document, semanticModel, modulePartNode, this.analysisData);
+        analyzeGenerateMethod(semanticModel, modulePartNode, anthropicModelProviderSymbol, this.analysisData);
     }
 
     private static TextDocument modifyDocument(Document document, ModifierData modifierData) {
@@ -157,9 +166,10 @@ class GenerateMethodModificationTask implements ModifierTask<SourceModifierConte
         return NodeParser.parseImportDeclaration(String.format("import %s/%s;", BALLERINA_ORG_NAME, AI_MODULE_NAME));
     }
 
-    private void analyzeGenerateMethod(Document document, SemanticModel semanticModel,
-                                   ModulePartNode modulePartNode, AiAnthropicCodeModifier.AnalysisData analysisData) {
-        new GenerateMethodJsonSchemaGenerator(semanticModel, document, analysisData)
+    private void analyzeGenerateMethod(SemanticModel semanticModel,
+                                       ModulePartNode modulePartNode, Optional<Symbol> anthropicModelProviderSymbol,
+                                       AiAnthropicCodeModifier.AnalysisData analysisData) {
+        new GenerateMethodJsonSchemaGenerator(semanticModel, anthropicModelProviderSymbol, analysisData)
                 .generate(modulePartNode);
     }
 
@@ -198,24 +208,29 @@ class GenerateMethodModificationTask implements ModifierTask<SourceModifierConte
 
     private class GenerateMethodJsonSchemaGenerator extends NodeVisitor {
         private static final String GENERATE_METHOD_NAME = "generate";
-        private static final String ANTHROPIC_MODEL_PROVIDER_NAME = "ModelProvider";
-        private static final String ANTHROPIC_MODEL_PROVIDER_MODULE_NAME = "ai.anthropic";
-        private static final String ANTHROPIC_MODEL_PROVIDER_MODULE_VERSION = "1";
-        private static final String ANTHROPIC_MODEL_PROVIDER_MODULE_ORG = "ballerinax";
         private static final String STRING = "string";
         private static final String BYTE = "byte";
         private static final String NUMBER = "number";
         private final SemanticModel semanticModel;
-        private final Document document;
         private final TypeMapper typeMapper;
         private final ClassSymbol anthropicProviderSymbol;
 
-        public GenerateMethodJsonSchemaGenerator(SemanticModel semanticModel, Document document,
+        public GenerateMethodJsonSchemaGenerator(SemanticModel semanticModel,
+                                                 Optional<Symbol> anthropicModelProviderSymbolOpt,
                                                  AiAnthropicCodeModifier.AnalysisData analyserData) {
-            this.semanticModel = semanticModel;
-            this.document = document;
+            this.semanticModel = semanticModel;;
             this.typeMapper = analyserData.typeMapper;
-            this.anthropicProviderSymbol = getAnthropicProviderSymbol(document.syntaxTree().rootNode()).orElse(null);
+            if (anthropicModelProviderSymbolOpt.isEmpty()) {
+                this.anthropicProviderSymbol = null;
+                return;
+            }
+
+            Symbol anthropicModelProviderSymbol = anthropicModelProviderSymbolOpt.get();
+            if (anthropicModelProviderSymbol instanceof ClassSymbol anthropicModelProviderClassSymbol) {
+                this.anthropicProviderSymbol = anthropicModelProviderClassSymbol;
+            } else {
+                this.anthropicProviderSymbol = null;
+            }
         }
 
         void generate(ModulePartNode modulePartNode) {
@@ -267,37 +282,6 @@ class GenerateMethodModificationTask implements ModifierTask<SourceModifierConte
                         populateTypeSchema(member, typeMapper, typeSchemas, anydataType));
                 default -> { }
             }
-        }
-
-        private Optional<ClassSymbol> getAnthropicProviderSymbol(Node node) {
-            Optional<ModuleSymbol> anthropicModuleSymbol = getAnthropicModuleSymbol(node);
-            if (anthropicModuleSymbol.isEmpty()) {
-                return Optional.empty();
-            }
-
-            for (ClassSymbol classSymbol: anthropicModuleSymbol.get().classes()) {
-                if (classSymbol.nameEquals(ANTHROPIC_MODEL_PROVIDER_NAME)) {
-                    return Optional.of(classSymbol);
-                }
-            }
-
-            return Optional.empty();
-        }
-
-        private Optional<ModuleSymbol> getAnthropicModuleSymbol(Node node) {
-            for (Symbol symbol : semanticModel.visibleSymbols(this.document, node.lineRange().startLine())) {
-                if (!(symbol instanceof ModuleSymbol moduleSymbol)) {
-                    continue;
-                }
-
-                ModuleID id = moduleSymbol.id();
-                if (ANTHROPIC_MODEL_PROVIDER_MODULE_ORG.equals(id.orgName())
-                        && ANTHROPIC_MODEL_PROVIDER_MODULE_NAME.equals(id.moduleName())
-                        && id.version().startsWith(ANTHROPIC_MODEL_PROVIDER_MODULE_VERSION)) {
-                    return Optional.of(moduleSymbol);
-                }
-            }
-            return Optional.empty();
         }
 
         private static String getJsonSchema(Schema schema) {


### PR DESCRIPTION
Update anthropic module compiler plugin to support generate API calls when the anthropic import is not present in the file

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8126