### PR TITLE
Update inbuilt tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ballerina Anthropic Model Provider Library
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-ai.anthropic/workflows/CI/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.anthropic/actions?query=workflow%3ACI)
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-ai.anthropic.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.anthropic/commits/master)
+[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-ai.anthropic.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.anthropic/commits/main)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Overview

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,6 +25,12 @@ version="1.10.0"
 repository="local"
 
 [[dependency]]
+org="ballerinax"
+name="ai.anthropic"
+version="1.3.1"
+repository="local"
+
+[[dependency]]
 org="ballerina"
 name="data.jsondata"
 version="1.1.4"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,12 +25,6 @@ version="1.10.0"
 repository="local"
 
 [[dependency]]
-org="ballerinax"
-name="ai.anthropic"
-version="1.3.1"
-repository="local"
-
-[[dependency]]
 org="ballerina"
 name="data.jsondata"
 version="1.1.4"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -15,5 +15,17 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.anthropic-native"
-version = "1.3.1"
-path = "../native/build/libs/ai.anthropic-native-1.3.1.jar"
+version = "1.3.0"
+path = "../native/build/libs/ai.anthropic-native-1.3.0.jar"
+
+[[dependency]]
+org="ballerina"
+name="ai"
+version="1.10.0"
+repository="local"
+
+[[dependency]]
+org="ballerina"
+name="data.jsondata"
+version="1.1.4"
+repository="local"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.anthropic"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.anthropic"
-version = "1.3.1"
+version = "1.4.0"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,13 +15,13 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.anthropic-native"
-version = "1.3.1"
-path = "../native/build/libs/ai.anthropic-native-1.3.1-SNAPSHOT.jar"
+version = "1.4.0"
+path = "../native/build/libs/ai.anthropic-native-1.4.0-SNAPSHOT.jar"
 
 [[dependency]]
 org="ballerina"
 name="ai"
-version="1.10.0"
+version="1.11.0"
 repository="local"
 
 [[dependency]]

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.anthropic-native"
-version = "1.3.0"
-path = "../native/build/libs/ai.anthropic-native-1.3.0.jar"
+version = "1.3.1"
+path = "../native/build/libs/ai.anthropic-native-1.3.1-SNAPSHOT.jar"
 
 [[dependency]]
 org="ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,8 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.9.0"
+version = "1.10.0"
+
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -139,6 +139,10 @@ dependencies = [
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "url"}
 ]
+modules = [
+	{org = "ballerina", packageName = "http", moduleName = "http"},
+	{org = "ballerina", packageName = "http", moduleName = "http.httpscerr"}
+]
 
 [[package]]
 org = "ballerina"
@@ -395,6 +399,7 @@ version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},
+	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -139,10 +139,6 @@ dependencies = [
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "url"}
 ]
-modules = [
-	{org = "ballerina", packageName = "http", moduleName = "http"},
-	{org = "ballerina", packageName = "http", moduleName = "http.httpscerr"}
-]
 
 [[package]]
 org = "ballerina"
@@ -395,11 +391,10 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.anthropic"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},
-	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -85,7 +85,7 @@ public isolated client class ModelProvider {
     # + tools - Tool definitions to be used for the tool call
     # + stop - Stop sequence to stop the completion (not used in this implementation)
     # + return - Chat response or an error in case of failures
-    isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages, (ai:ChatCompletionFunctions|ai:InbuiltModelTool)[] tools = [], string? stop = ())
+    isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages, (ai:ChatCompletionFunctions|ai:BuiltInTool)[] tools = [], string? stop = ())
         returns ai:ChatAssistantMessage|ai:Error {
         observe:ChatSpan span = observe:createChatSpan(self.modelType);
         span.addProvider("anthropic");
@@ -118,28 +118,28 @@ public isolated client class ModelProvider {
         // If tools are provided, add them to the request
         if tools.length() > 0 {
             ai:ChatCompletionFunctions[] functionTools = [];
-            ai:InbuiltModelTool[] inbuiltTools = [];
-            foreach ai:ChatCompletionFunctions|ai:InbuiltModelTool tool in tools {
+            ai:BuiltInTool[] builtInTools = [];
+            foreach ai:ChatCompletionFunctions|ai:BuiltInTool tool in tools {
                 if tool is ai:ChatCompletionFunctions {
                     functionTools.push(tool);
                 } else {
-                    inbuiltTools.push(tool);
+                    builtInTools.push(tool);
                 }
             }
 
-            // Validate inbuilt tools — only web_search and code_execution are supported
-            foreach ai:InbuiltModelTool inbuiltTool in inbuiltTools {
-                if inbuiltTool !is CodeExecutionTool && inbuiltTool !is WebSearchTool {
-                    ai:Error err = error ai:Error(string `Unsupported inbuilt tool: '${inbuiltTool.name}'. `
-                        + "The Anthropic model provider currently only supports 'web_search' and 'code_execution' inbuilt tools.");
+            // Validate built-in tools — only web_search and code_execution are supported
+            foreach ai:BuiltInTool builtInTool in builtInTools {
+                if builtInTool !is CodeExecutionTool && builtInTool !is WebSearchTool {
+                    ai:Error err = error ai:Error(string `Unsupported built-in tool: '${builtInTool.name}'. `
+                        + "The Anthropic model provider currently only supports 'web_search' and 'code_execution' built-in tools.");
                     span.close(err);
                     return err;
                 }
             }
 
             json[] toolsPayload = self.mapToAnthropicTools(functionTools);
-            foreach ai:InbuiltModelTool inbuiltTool in inbuiltTools {
-                toolsPayload.push(self.mapInbuiltToolToJson(inbuiltTool));
+            foreach ai:BuiltInTool builtInTool in builtInTools {
+                toolsPayload.push(self.mapBuiltInToolToJson(builtInTool));
             }
 
             span.addTools(toolsPayload);
@@ -263,11 +263,11 @@ public isolated client class ModelProvider {
         return anthropicTools;
     }
 
-    # Maps an inbuilt model tool to the Anthropic API JSON format
+    # Maps a built-in model tool to the Anthropic API JSON format
     #
-    # + tool - The inbuilt model tool to map
+    # + tool - The built-in model tool to map
     # + return - JSON representation for the Anthropic API tools array
-    private isolated function mapInbuiltToolToJson(ai:InbuiltModelTool tool) returns json {
+    private isolated function mapBuiltInToolToJson(ai:BuiltInTool tool) returns json {
         if tool.name == WEB_SEARCH_TOOL_NAME {
             return self.mapWebSearchToolToJson(tool);
         }
@@ -276,9 +276,9 @@ public isolated client class ModelProvider {
 
     # Maps a web search tool to the Anthropic API JSON format
     #
-    # + tool - The inbuilt model tool (expected to be a web search tool)
+    # + tool - The built-in model tool (expected to be a web search tool)
     # + return - JSON representation for the Anthropic API
-    private isolated function mapWebSearchToolToJson(ai:InbuiltModelTool tool) returns json {
+    private isolated function mapWebSearchToolToJson(ai:BuiltInTool tool) returns json {
         map<anydata>? configurations = tool.configurations;
 
         // Get version from configurations, or use default
@@ -332,9 +332,9 @@ public isolated client class ModelProvider {
 
     # Maps a code execution tool to the Anthropic API JSON format
     #
-    # + tool - The inbuilt model tool (expected to be a code execution tool)
+    # + tool - The built-in model tool (expected to be a code execution tool)
     # + return - JSON representation for the Anthropic API
-    private isolated function mapCodeExecutionToolToJson(ai:InbuiltModelTool tool) returns json {
+    private isolated function mapCodeExecutionToolToJson(ai:BuiltInTool tool) returns json {
         map<anydata>? configurations = tool.configurations;
 
         // Get version from configurations, or use default

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -129,7 +129,7 @@ public isolated client class ModelProvider {
 
             // Validate inbuilt tools — only web_search and code_execution are supported
             foreach ai:InbuiltModelTool inbuiltTool in inbuiltTools {
-                if inbuiltTool.name != WEB_SEARCH_TOOL_NAME && inbuiltTool.name != CODE_EXECUTION_TOOL_NAME {
+                if inbuiltTool !is CodeExecutionTool && inbuiltTool !is WebSearchTool {
                     ai:Error err = error ai:Error(string `Unsupported inbuilt tool: '${inbuiltTool.name}'. `
                         + "The Anthropic model provider currently only supports 'web_search' and 'code_execution' inbuilt tools.");
                     span.close(err);

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -85,7 +85,7 @@ public isolated client class ModelProvider {
     # + tools - Tool definitions to be used for the tool call
     # + stop - Stop sequence to stop the completion (not used in this implementation)
     # + return - Chat response or an error in case of failures
-    isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages, ai:ChatCompletionFunctions[] tools = [], string? stop = ())
+    isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages, (ai:ChatCompletionFunctions|ai:InbuiltModelTool)[] tools = [], string? stop = ())
         returns ai:ChatAssistantMessage|ai:Error {
         observe:ChatSpan span = observe:createChatSpan(self.modelType);
         span.addProvider("anthropic");
@@ -117,8 +117,33 @@ public isolated client class ModelProvider {
 
         // If tools are provided, add them to the request
         if tools.length() > 0 {
-            span.addTools(tools);
-            requestPayload["tools"] = self.mapToAnthropicTools(tools);
+            ai:ChatCompletionFunctions[] functionTools = [];
+            ai:InbuiltModelTool[] inbuiltTools = [];
+            foreach ai:ChatCompletionFunctions|ai:InbuiltModelTool tool in tools {
+                if tool is ai:ChatCompletionFunctions {
+                    functionTools.push(tool);
+                } else {
+                    inbuiltTools.push(tool);
+                }
+            }
+
+            // Validate inbuilt tools — only web_search and code_execution are supported
+            foreach ai:InbuiltModelTool inbuiltTool in inbuiltTools {
+                if inbuiltTool.name != WEB_SEARCH_TOOL_NAME && inbuiltTool.name != CODE_EXECUTION_TOOL_NAME {
+                    ai:Error err = error ai:Error(string `Unsupported inbuilt tool: '${inbuiltTool.name}'. `
+                        + "The Anthropic model provider currently only supports 'web_search' and 'code_execution' inbuilt tools.");
+                    span.close(err);
+                    return err;
+                }
+            }
+
+            json[] toolsPayload = self.mapToAnthropicTools(functionTools);
+            foreach ai:InbuiltModelTool inbuiltTool in inbuiltTools {
+                toolsPayload.push(self.mapInbuiltToolToJson(inbuiltTool));
+            }
+
+            span.addTools(toolsPayload);
+            requestPayload["tools"] = toolsPayload;
         }
 
         // Send request to Anthropic API with proper headers
@@ -224,24 +249,104 @@ public isolated client class ModelProvider {
     # Maps ai:ChatCompletionFunctions to Anthropic's tool format
     #
     # + tools - Array of tool definitions
-    # + return - Array of Anthropic tool definitions
-    private isolated function mapToAnthropicTools(ai:ChatCompletionFunctions[] tools) returns AnthropicTool[] {
-        AnthropicTool[] anthropicTools = [];
-
+    # + return - Array of Anthropic tool definitions as JSON
+    private isolated function mapToAnthropicTools(ai:ChatCompletionFunctions[] tools) returns json[] {
+        json[] anthropicTools = [];
         foreach ai:ChatCompletionFunctions tool in tools {
             map<json> schema = tool.parameters ?: {'type: "object", properties: {}};
-
-            // Create Anthropic tool with input_schema instead of parameters
-            AnthropicTool AnthropicTool = {
+            anthropicTools.push({
                 name: tool.name,
                 description: tool.description,
                 input_schema: schema
-            };
+            });
+        }
+        return anthropicTools;
+    }
 
-            anthropicTools.push(AnthropicTool);
+    # Maps an inbuilt model tool to the Anthropic API JSON format
+    #
+    # + tool - The inbuilt model tool to map
+    # + return - JSON representation for the Anthropic API tools array
+    private isolated function mapInbuiltToolToJson(ai:InbuiltModelTool tool) returns json {
+        if tool.name == WEB_SEARCH_TOOL_NAME {
+            return self.mapWebSearchToolToJson(tool);
+        }
+        return self.mapCodeExecutionToolToJson(tool);
+    }
+
+    # Maps a web search tool to the Anthropic API JSON format
+    #
+    # + tool - The inbuilt model tool (expected to be a web search tool)
+    # + return - JSON representation for the Anthropic API
+    private isolated function mapWebSearchToolToJson(ai:InbuiltModelTool tool) returns json {
+        map<anydata>? configurations = tool.configurations;
+
+        // Get version from configurations, or use default
+        string toolType = DEFAULT_WEB_SEARCH_TOOL_TYPE;
+        if configurations is map<anydata> {
+            anydata configType = configurations["type"];
+            if configType is string {
+                toolType = configType;
+            }
         }
 
-        return anthropicTools;
+        map<json> result = {"type": toolType, "name": WEB_SEARCH_TOOL_NAME};
+        if configurations is () {
+            return result;
+        }
+        anydata maxUses = configurations["max_uses"];
+        if maxUses is int {
+            result["max_uses"] = maxUses;
+        }
+        anydata allowedDomains = configurations["allowed_domains"];
+        if allowedDomains is string[] {
+            result["allowed_domains"] = allowedDomains;
+        }
+        anydata blockedDomains = configurations["blocked_domains"];
+        if blockedDomains is string[] {
+            result["blocked_domains"] = blockedDomains;
+        }
+        anydata userLocation = configurations["user_location"];
+        if userLocation is map<anydata> {
+            map<json> location = {"type": "approximate"};
+            anydata city = userLocation["city"];
+            if city is string {
+                location["city"] = city;
+            }
+            anydata region = userLocation["region"];
+            if region is string {
+                location["region"] = region;
+            }
+            anydata country = userLocation["country"];
+            if country is string {
+                location["country"] = country;
+            }
+            anydata timezone = userLocation["timezone"];
+            if timezone is string {
+                location["timezone"] = timezone;
+            }
+            result["user_location"] = location;
+        }
+        return result;
+    }
+
+    # Maps a code execution tool to the Anthropic API JSON format
+    #
+    # + tool - The inbuilt model tool (expected to be a code execution tool)
+    # + return - JSON representation for the Anthropic API
+    private isolated function mapCodeExecutionToolToJson(ai:InbuiltModelTool tool) returns json {
+        map<anydata>? configurations = tool.configurations;
+
+        // Get version from configurations, or use default
+        string toolType = DEFAULT_CODE_EXECUTION_TOOL_TYPE;
+        if configurations is map<anydata> {
+            anydata configType = configurations["type"];
+            if configType is string {
+                toolType = configType;
+            }
+        }
+
+        return {"type": toolType, "name": CODE_EXECUTION_TOOL_NAME};
     }
 }
 

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -139,7 +139,12 @@ public isolated client class ModelProvider {
 
             json[] toolsPayload = self.mapToAnthropicTools(functionTools);
             foreach ai:BuiltInTool builtInTool in builtInTools {
-                toolsPayload.push(self.mapBuiltInToolToJson(builtInTool));
+                json|ai:Error builtInToolJson = self.mapBuiltInToolToJson(builtInTool);
+                if builtInToolJson is ai:Error {
+                    span.close(builtInToolJson);
+                    return builtInToolJson;
+                }
+                toolsPayload.push(builtInToolJson);
             }
 
             span.addTools(toolsPayload);
@@ -266,8 +271,8 @@ public isolated client class ModelProvider {
     # Maps a built-in model tool to the Anthropic API JSON format
     #
     # + tool - The built-in model tool to map
-    # + return - JSON representation for the Anthropic API tools array
-    private isolated function mapBuiltInToolToJson(ai:BuiltInTool tool) returns json {
+    # + return - JSON representation for the Anthropic API tools array or an error
+    private isolated function mapBuiltInToolToJson(ai:BuiltInTool tool) returns json|ai:Error {
         if tool.name == WEB_SEARCH_TOOL_NAME {
             return self.mapWebSearchToolToJson(tool);
         }
@@ -277,8 +282,8 @@ public isolated client class ModelProvider {
     # Maps a web search tool to the Anthropic API JSON format
     #
     # + tool - The built-in model tool (expected to be a web search tool)
-    # + return - JSON representation for the Anthropic API
-    private isolated function mapWebSearchToolToJson(ai:BuiltInTool tool) returns json {
+    # + return - JSON representation for the Anthropic API or an error
+    private isolated function mapWebSearchToolToJson(ai:BuiltInTool tool) returns json|ai:Error {
         map<anydata>? configurations = tool.configurations;
 
         // Get version from configurations, or use default
@@ -299,10 +304,14 @@ public isolated client class ModelProvider {
             result["max_uses"] = maxUses;
         }
         anydata allowedDomains = configurations["allowed_domains"];
+        anydata blockedDomains = configurations["blocked_domains"];
+        if allowedDomains is string[] && blockedDomains is string[] {
+            return error ai:Error("'allowed_domains' and 'blocked_domains' are mutually exclusive in web search tool configuration");
+        }
+        
         if allowedDomains is string[] {
             result["allowed_domains"] = allowedDomains;
         }
-        anydata blockedDomains = configurations["blocked_domains"];
         if blockedDomains is string[] {
             result["blocked_domains"] = blockedDomains;
         }

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -18,36 +18,121 @@ import ballerina/http;
 import ballerina/test;
 
 service /llm on new http:Listener(8080) {
-    resource function post anthropic/messages(map<json> payload)returns AnthropicApiResponse|error {
+    resource function post anthropic/messages(map<json> payload) returns AnthropicApiResponse|error {
         test:assertEquals(payload["model"], CLAUDE_3_7_SONNET_20250219);
         test:assertEquals(payload["max_tokens"], 512);
         test:assertEquals(payload["temperature"], 0.7d);
 
         json[] messages = check payload["messages"].ensureType();
-        map<json> message = check messages[0].ensureType();
-        json[]? content = check message["content"].ensureType();
-        if content is () {
-            test:assertFail("Expected content in the payload");
-        }
-
-        TextContentPart initialTextContent = check content[0].fromJsonWithType();
-        string initialText = initialTextContent.text.toString();
-        test:assertEquals(message["role"], "user");
-        test:assertEquals(content, getExpectedContentParts(initialText));
         json[]? tools = check payload["tools"].ensureType();
-        if tools is () || tools.length() == 0 {
-            test:assertFail("No tools in the payload");
+
+        // Determine if this is a generate() call (has getResults tool) or a chat() call
+        boolean isGenerateCall = false;
+        boolean hasBuiltInTool = false;
+        if tools is json[] && tools.length() > 0 {
+            map<json> firstTool = check tools[0].ensureType();
+            json? toolName = firstTool["name"];
+            if toolName == GET_RESULTS_TOOL {
+                isGenerateCall = true;
+            }
+            // Check for built-in tools (they have 'type' starting with "web_search_" or "code_execution_")
+            foreach json tool in tools {
+                map<json> toolMap = check tool.ensureType();
+                string? toolType = check toolMap["type"].ensureType();
+                if toolType is string &&
+                        (toolType.startsWith("web_search") || toolType.startsWith("code_execution")) {
+                    hasBuiltInTool = true;
+                }
+            }
         }
 
-        map<json> tool = check tools[0].ensureType();
-        map<json>? parameters = check tool["input_schema"].ensureType();
-        if parameters is () {
-            test:assertFail("No parameters in the expected tool in the test with content: " 
-                + content.toJsonString());
+        if isGenerateCall {
+            // Existing generate() path
+            map<json> message = check messages[0].ensureType();
+            json[]? content = check message["content"].ensureType();
+            if content is () {
+                test:assertFail("Expected content in the payload");
+            }
+
+            TextContentPart initialTextContent = check content[0].fromJsonWithType();
+            string initialText = initialTextContent.text.toString();
+            test:assertEquals(message["role"], "user");
+            test:assertEquals(content, getExpectedContentParts(initialText));
+            if tools is () || tools.length() == 0 {
+                test:assertFail("No tools in the payload");
+            }
+
+            map<json> tool = check tools[0].ensureType();
+            map<json>? parameters = check tool["input_schema"].ensureType();
+            if parameters is () {
+                test:assertFail("No parameters in the expected tool in the test with content: "
+                    + content.toJsonString());
+            }
+
+            test:assertEquals(parameters, getExpectedParameterSchema(initialText),
+                    string `Test failed for prompt with initial content, ${initialText}`);
+            return getTestServiceResponse(initialText);
         }
 
-        test:assertEquals(parameters, getExpectedParameterSchema(initialText),
-                string `Test failed for prompt with initial content, ${initialText}`);
-        return getTestServiceResponse(initialText);
+        // Chat path: extract user message content
+        string userContent = "";
+        foreach json msg in messages {
+            map<json> msgMap = check msg.ensureType();
+            if msgMap["role"] == "user" {
+                anydata msgContent = msgMap["content"];
+                if msgContent is string {
+                    userContent = msgContent;
+                }
+            }
+        }
+
+        // Chat with built-in tools - return text response
+        if hasBuiltInTool {
+            return getTestChatResponse(userContent);
+        }
+
+        // Chat with function tools - return tool call response
+        if tools is json[] && tools.length() > 0 {
+            return getTestChatToolCallResponse();
+        }
+
+        // Simple chat - return text response
+        return getTestChatResponse(userContent);
     }
+}
+
+// Builds a chat response with text content
+isolated function getTestChatResponse(string content) returns AnthropicApiResponse {
+    return {
+        id: "msg_chat_test",
+        'type: "message",
+        model: CLAUDE_3_7_SONNET_20250219,
+        role: "assistant",
+        content: [{
+            'type: "text",
+            text: "This is a mock response for: " + content
+        }],
+        stop_reason: "end_turn",
+        stop_sequence: (),
+        usage: {input_tokens: 50, output_tokens: 30}
+    };
+}
+
+// Builds a chat response with a tool call
+isolated function getTestChatToolCallResponse() returns AnthropicApiResponse {
+    return {
+        id: "msg_chat_tool_test",
+        'type: "message",
+        model: CLAUDE_3_7_SONNET_20250219,
+        role: "assistant",
+        content: [{
+            'type: "tool_use",
+            id: "toolu_test_123",
+            name: "get_weather",
+            input: {"city": "London"}
+        }],
+        stop_reason: "tool_use",
+        stop_sequence: (),
+        usage: {input_tokens: 80, output_tokens: 20}
+    };
 }

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -86,8 +86,38 @@ service /llm on new http:Listener(8080) {
             }
         }
 
-        // Chat with built-in tools - return text response
+        // Chat with built-in tools - validate tools payload and return text response
         if hasBuiltInTool {
+            json[] toolsArr = check payload["tools"].ensureType();
+            if userContent == "Search with allowed domains" {
+                check validateWebSearchToolPayload(toolsArr, allowedDomains = ["example.com", "test.org"]);
+            } else if userContent == "Search with blocked domains" {
+                check validateWebSearchToolPayload(toolsArr, blockedDomains = ["spam.com"]);
+            } else if userContent == "Search with location" {
+                check validateWebSearchToolPayload(toolsArr, userLocation = {
+                    "type": "approximate",
+                    "city": "San Francisco",
+                    "region": "California",
+                    "country": "US",
+                    "timezone": "America/Los_Angeles"
+                });
+            } else if userContent == "Search with max uses" {
+                check validateWebSearchToolPayload(toolsArr, maxUses = 3);
+            } else if userContent == "Execute code custom type" {
+                map<json> tool = check toolsArr[0].ensureType();
+                test:assertEquals(tool["type"], "code_execution_20250522");
+                test:assertEquals(tool["name"], "code_execution");
+            } else if userContent == "Mixed tools test" {
+                test:assertEquals(toolsArr.length(), 2);
+                // One should be a function tool (has input_schema), other a built-in tool
+                map<json> firstTool = check toolsArr[0].ensureType();
+                map<json> secondTool = check toolsArr[1].ensureType();
+                test:assertEquals(firstTool["name"], "get_weather");
+                test:assertTrue(firstTool.hasKey("input_schema"));
+                test:assertEquals(secondTool["name"], "web_search");
+                string? secondType = check secondTool["type"].ensureType();
+                test:assertTrue(secondType is string && secondType.startsWith("web_search"));
+            }
             return getTestChatResponse(userContent);
         }
 
@@ -116,6 +146,32 @@ isolated function getTestChatResponse(string content) returns AnthropicApiRespon
         stop_sequence: (),
         usage: {input_tokens: 50, output_tokens: 30}
     };
+}
+
+// Validates a web search tool payload in the tools array
+isolated function validateWebSearchToolPayload(json[] tools,
+        string[]? allowedDomains = (), string[]? blockedDomains = (),
+        map<json>? userLocation = (), int? maxUses = ()) returns error? {
+    map<json> tool = check tools[0].ensureType();
+    test:assertEquals(tool["name"], "web_search");
+    string? toolType = check tool["type"].ensureType();
+    test:assertTrue(toolType is string && toolType.startsWith("web_search"));
+    if allowedDomains is string[] {
+        json[] actual = check tool["allowed_domains"].ensureType();
+        test:assertEquals(actual, allowedDomains.toJson());
+    }
+    if blockedDomains is string[] {
+        json[] actual = check tool["blocked_domains"].ensureType();
+        test:assertEquals(actual, blockedDomains.toJson());
+    }
+    if userLocation is map<json> {
+        map<json> actual = check tool["user_location"].ensureType();
+        test:assertEquals(actual, userLocation);
+    }
+    if maxUses is int {
+        int actual = check tool["max_uses"].ensureType();
+        test:assertEquals(actual, maxUses);
+    }
 }
 
 // Builds a chat response with a tool call

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -407,3 +407,110 @@ function testChatWithUnsupportedBuiltInTool() returns error? {
     test:assertTrue(errorMsg.includes("Unsupported built-in tool: 'unsupported_tool'"),
             string `expected unsupported built-in tool error, found: ${errorMsg}`);
 }
+
+@test:Config
+function testChatWithWebSearchToolAllowedDomains() returns ai:Error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search with allowed domains"};
+    WebSearchTool webSearchTool = {
+        name: "web_search",
+        configurations: {
+            allowed_domains: ["example.com", "test.org"]
+        }
+    };
+    ai:ChatAssistantMessage result = check claudeProvider->chat(userMsg, [webSearchTool]);
+    test:assertTrue(result.content is string);
+}
+
+@test:Config
+function testChatWithWebSearchToolBlockedDomains() returns ai:Error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search with blocked domains"};
+    WebSearchTool webSearchTool = {
+        name: "web_search",
+        configurations: {
+            blocked_domains: ["spam.com"]
+        }
+    };
+    ai:ChatAssistantMessage result = check claudeProvider->chat(userMsg, [webSearchTool]);
+    test:assertTrue(result.content is string);
+}
+
+@test:Config
+function testChatWithWebSearchToolMutualExclusionError() returns error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search with both domains"};
+    WebSearchTool webSearchTool = {
+        name: "web_search",
+        configurations: {
+            allowed_domains: ["example.com"],
+            blocked_domains: ["spam.com"]
+        }
+    };
+    ai:ChatAssistantMessage|ai:Error result = claudeProvider->chat(userMsg, [webSearchTool]);
+    test:assertTrue(result is ai:Error);
+    string errorMsg = (<ai:Error>result).message();
+    test:assertTrue(errorMsg.includes("mutually exclusive"),
+            string `expected mutual exclusion error, found: ${errorMsg}`);
+}
+
+@test:Config
+function testChatWithWebSearchToolUserLocation() returns ai:Error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search with location"};
+    WebSearchTool webSearchTool = {
+        name: "web_search",
+        configurations: {
+            user_location: {
+                city: "San Francisco",
+                region: "California",
+                country: "US",
+                timezone: "America/Los_Angeles"
+            }
+        }
+    };
+    ai:ChatAssistantMessage result = check claudeProvider->chat(userMsg, [webSearchTool]);
+    test:assertTrue(result.content is string);
+}
+
+@test:Config
+function testChatWithWebSearchToolMaxUses() returns ai:Error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search with max uses"};
+    WebSearchTool webSearchTool = {
+        name: "web_search",
+        configurations: {
+            max_uses: 3
+        }
+    };
+    ai:ChatAssistantMessage result = check claudeProvider->chat(userMsg, [webSearchTool]);
+    test:assertTrue(result.content is string);
+}
+
+@test:Config
+function testChatWithCodeExecutionToolCustomType() returns ai:Error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Execute code custom type"};
+    CodeExecutionTool codeExecTool = {
+        name: "code_execution",
+        configurations: {
+            'type: "code_execution_20250522"
+        }
+    };
+    ai:ChatAssistantMessage result = check claudeProvider->chat(userMsg, [codeExecTool]);
+    test:assertTrue(result.content is string);
+}
+
+@test:Config
+function testChatWithMixedTools() returns ai:Error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Mixed tools test"};
+    ai:ChatCompletionFunctions functionTool = {
+        name: "get_weather",
+        description: "Get weather for a city",
+        parameters: {
+            'type: "object",
+            properties: {
+                "city": {'type: "string"}
+            }
+        }
+    };
+    WebSearchTool webSearchTool = {
+        name: "web_search"
+    };
+    ai:ChatAssistantMessage result = check claudeProvider->chat(userMsg, [functionTool, webSearchTool]);
+    test:assertTrue(result.content is string);
+}

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -374,3 +374,36 @@ function testGenerateMethodWithArrayUnionRecord2() returns ai:Error? {
    Cricketers7[]|Cricketers8|error result = claudeProvider->generate(`Name a random world class cricketer`);
     test:assertTrue(result is Cricketers8);
 }
+
+// ===== Built-in tool tests =====
+
+@test:Config
+function testChatWithWebSearchTool() returns ai:Error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search for latest news"};
+    WebSearchTool webSearchTool = {
+        name: "web_search"
+    };
+    ai:ChatAssistantMessage result = check claudeProvider->chat(userMsg, [webSearchTool]);
+    test:assertTrue(result.content is string);
+}
+
+@test:Config
+function testChatWithCodeExecutionTool() returns ai:Error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Run some code"};
+    CodeExecutionTool codeExecTool = {
+        name: "code_execution"
+    };
+    ai:ChatAssistantMessage result = check claudeProvider->chat(userMsg, [codeExecTool]);
+    test:assertTrue(result.content is string);
+}
+
+@test:Config
+function testChatWithUnsupportedBuiltInTool() returns error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Use an unsupported tool"};
+    ai:BuiltInTool unsupportedTool = {name: "unsupported_tool"};
+    ai:ChatAssistantMessage|ai:Error result = claudeProvider->chat(userMsg, [unsupportedTool]);
+    test:assertTrue(result is ai:Error);
+    string errorMsg = (<ai:Error>result).message();
+    test:assertTrue(errorMsg.includes("Unsupported built-in tool: 'unsupported_tool'"),
+            string `expected unsupported built-in tool error, found: ${errorMsg}`);
+}

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/ai;
 import ballerina/http;
 
 # Configurations for controlling the behaviours when communicating with a remote HTTP endpoint.
@@ -135,8 +136,10 @@ public type WebSearchToolConfig record {|
 
 # Web search tool for Anthropic models.
 # Gives Claude access to real-time web content with cited sources.
+# Ref: https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/web-search-tool
 public type WebSearchTool record {|
-    # Name of the tool
+    *ai:BuiltInTool;
+    # Tool identifier. Always `"web_search"`.
     "web_search" name = "web_search";
     # Web search tool configurations
     WebSearchToolConfig configurations?;
@@ -154,8 +157,10 @@ public type CodeExecutionToolConfig record {|
 
 # Code execution tool for Anthropic models.
 # Allows Claude to run code in a sandboxed environment.
+# Ref: https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/code-execution-tool
 public type CodeExecutionTool record {|
-    # Name of the tool
+    *ai:BuiltInTool;
+    # Tool identifier. Always `"code_execution"`.
     "code_execution" name = "code_execution";
     # Code execution tool configurations
     CodeExecutionToolConfig configurations?;

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -100,6 +100,67 @@ public enum ANTHROPIC_MODEL_NAMES {
     CLAUDE_3_HAIKU_20240307 = "claude-3-haiku-20240307"
 }
 
+const WEB_SEARCH_TOOL_NAME = "web_search";
+const CODE_EXECUTION_TOOL_NAME = "code_execution";
+const string DEFAULT_WEB_SEARCH_TOOL_TYPE = "web_search_20250305";
+const string DEFAULT_CODE_EXECUTION_TOOL_TYPE = "code_execution_20250825";
+
+# Approximate user location for localizing web search results.
+public type UserLocation record {|
+    # The city name (e.g., "San Francisco")
+    string city?;
+    # The region or state (e.g., "California")
+    string region?;
+    # The ISO country code (e.g., "US")
+    string country?;
+    # The IANA timezone ID (e.g., "America/Los_Angeles")
+    string timezone?;
+|};
+
+# Configuration for the Anthropic web search tool.
+# Ref: https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/web-search-tool
+public type WebSearchToolConfig record {|
+    # The web search tool version. Defaults to "web_search_20250305".
+    # Use "web_search_20260209" for dynamic filtering (requires code_execution tool + Opus/Sonnet 4.6).
+    string 'type = DEFAULT_WEB_SEARCH_TOOL_TYPE;
+    # Maximum number of web searches allowed per request
+    int max_uses?;
+    # Only include results from these domains (mutually exclusive with blocked_domains)
+    string[] allowed_domains?;
+    # Never include results from these domains (mutually exclusive with allowed_domains)
+    string[] blocked_domains?;
+    # Approximate user location for localizing search results
+    UserLocation user_location?;
+|};
+
+# Web search tool for Anthropic models.
+# Gives Claude access to real-time web content with cited sources.
+public type WebSearchTool record {|
+    # Name of the tool
+    "web_search" name = "web_search";
+    # Web search tool configurations
+    WebSearchToolConfig configurations?;
+|};
+
+# Configuration for the Anthropic code execution tool.
+# Ref: https://platform.claude.com/docs/en/docs/agents-and-tools/tool-use/code-execution-tool
+public type CodeExecutionToolConfig record {|
+    # The code execution tool version. Defaults to "code_execution_20250825".
+    # Versions: "code_execution_20250522" (legacy Python-only),
+    #           "code_execution_20250825" (Bash + file ops),
+    #           "code_execution_20260120" (REPL state persistence).
+    string 'type = DEFAULT_CODE_EXECUTION_TOOL_TYPE;
+|};
+
+# Code execution tool for Anthropic models.
+# Allows Claude to run code in a sandboxed environment.
+public type CodeExecutionTool record {|
+    # Name of the tool
+    "code_execution" name = "code_execution";
+    # Code execution tool configurations
+    CodeExecutionToolConfig configurations?;
+|};
+
 # Anthropic API request message format
 type AnthropicMessage record {|
     # Role of the participant in the conversation (e.g., "user" or "assistant")

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -17,3 +17,15 @@ groupId = "io.ballerina.lib"
 artifactId = "ai.anthropic-native"
 version = "@toml.version@"
 path = "../native/build/libs/ai.anthropic-native-@project.version@.jar"
+
+[[dependency]]
+org="ballerina"
+name="ai"
+version="1.10.0"
+repository="local"
+
+[[dependency]]
+org="ballerina"
+name="data.jsondata"
+version="1.1.4"
+repository="local"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18
 ballerinaToOpenApiVersion=2.3.0
 swaggerVersion=2.2.9
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,3 @@ checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18
 ballerinaToOpenApiVersion=2.3.0
 swaggerVersion=2.2.9
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.3.2-SNAPSHOT
+version=1.4.0-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 
 shadowJarPluginVersion=8.1.1


### PR DESCRIPTION
Add built-in tool abstraction implementation

Fixes:
https://github.com/wso2-enterprise/integration-engineering/issues/80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request adds built-in tool abstraction implementation to the Anthropic AI module, introducing support for web search and code execution tools as integrated capabilities.

## Key Changes

**Core Feature Addition:**
- Extended the `ModelProvider.chat()` method to accept both standard functions and built-in tools as parameters
- Introduced new tool types: `WebSearchTool` and `CodeExecutionTool` with corresponding configuration records
- Added runtime validation to ensure only supported built-in tools are utilized, providing clear error feedback for unsupported tool types

**Implementation Details:**
- Refactored tool handling logic to map built-in tools to JSON representations compatible with Anthropic's API
- Added support for web search configuration including domain allowlists, domain blocklists, user location settings, and usage limits
- Added code execution tool support with customizable type configuration
- Updated dependency management to include the core AI module and JSON data handling library

**Testing & Validation:**
- Added 10 new test cases covering various built-in tool scenarios: basic web search and code execution functionality, domain filtering, user location configuration, usage limits, custom type configurations, and mixed tool usage
- Enhanced test service infrastructure to properly handle and validate built-in tool payloads

**Maintenance:**
- Updated package version from 1.3.1 to 1.4.0
- Updated related dependencies including the Anthropic native library
- Updated documentation link references from master to main branch

## Impact
This enhancement enables users to leverage real-time web search and code execution capabilities within Claude AI conversations, with proper validation and configuration controls to ensure reliable tool usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->