### PR TITLE
Feat/add claude opus 4.7 4.8

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -151,7 +151,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -106,9 +106,15 @@ public isolated client class ModelProvider {
         map<json> requestPayload = {
             model: self.modelType,
             max_tokens: self.maxTokens,
-            messages: anthropicMessages,
-            temperature: self.temperature
+            messages: anthropicMessages
         };
+
+        // Opus 4.7+ and newer reasoning models utilize internal dynamic sampling and 
+        // extended thinking architectures. External parameters like 'temperature' are 
+        // deprecated by Anthropic for these models and will trigger a 400 Bad Request.
+        if self.modelType != CLAUDE_OPUS_4_7 && self.modelType != CLAUDE_OPUS_4_8 {
+            requestPayload["temperature"] = self.temperature;
+        }
 
         if stop is string {
             span.addStopSequence(stop);

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -109,10 +109,7 @@ public isolated client class ModelProvider {
             messages: anthropicMessages
         };
 
-        // Opus 4.7+ and newer reasoning models utilize internal dynamic sampling and 
-        // extended thinking architectures. External parameters like 'temperature' are 
-        // deprecated by Anthropic for these models and will trigger a 400 Bad Request.
-        if self.modelType != CLAUDE_OPUS_4_7 && self.modelType != CLAUDE_OPUS_4_8 {
+        if supportsTemperature(self.modelType) {
             requestPayload["temperature"] = self.temperature;
         }
 

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -313,14 +313,19 @@ isolated function generateLlmResponse(http:Client anthropicClient, string apiKey
 
     map<json>[] messages = [{role: ai:USER, "content": chatContent}];
     span.addInputMessages(messages);
+
     map<json> request = {
         messages,
         model: modelType,
         max_tokens: maxTokens,
-        temperature,
         tools,
         tool_choice: getGetResultsToolChoice()
     };
+
+    // Add temperature only if the model is not Claude Opus 4.7 or 4.8
+    if modelType != CLAUDE_OPUS_4_7 && modelType != CLAUDE_OPUS_4_8 {
+        request["temperature"] = temperature;
+    }
 
     map<string> headers = {
         "x-api-key": apiKey,

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -322,8 +322,7 @@ isolated function generateLlmResponse(http:Client anthropicClient, string apiKey
         tool_choice: getGetResultsToolChoice()
     };
 
-    // Add temperature only if the model is not Claude Opus 4.7 or 4.8
-    if modelType != CLAUDE_OPUS_4_7 && modelType != CLAUDE_OPUS_4_8 {
+    if supportsTemperature(modelType) {
         request["temperature"] = temperature;
     }
 
@@ -397,4 +396,8 @@ isolated function getFunctionCallFromContentBlocks(ContentBlock[] blocks) return
         }
     }
     return functionCalls;
+}
+
+isolated function supportsTemperature(string modelType) returns boolean {
+    return modelType != CLAUDE_OPUS_4_7 && modelType != CLAUDE_OPUS_4_8;
 }

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/ai;
 import ballerina/http;
 import ballerina/test;
 
@@ -49,5 +50,28 @@ service /llm on new http:Listener(8080) {
         test:assertEquals(parameters, getExpectedParameterSchema(initialText),
                 string `Test failed for prompt with initial content, ${initialText}`);
         return getTestServiceResponse(initialText);
+    }
+}
+
+service /temptest on new http:Listener(7070) {
+    resource function post anthropic/messages(map<json> payload) returns AnthropicApiResponse|error {
+        string modelType = check payload["model"].ensureType();
+        if modelType == CLAUDE_OPUS_4_7 || modelType == CLAUDE_OPUS_4_8 {
+            test:assertFalse(payload.hasKey("temperature"),
+                string `temperature must be absent for model: ${modelType}`);
+        } else {
+            test:assertEquals(payload["temperature"], DEFAULT_TEMPERATURE,
+                string `temperature must be present for model: ${modelType}`);
+        }
+        return {
+            id: "temp-test-id",
+            model: modelType,
+            'type: "message",
+            stop_reason: "end_turn",
+            role: ai:ASSISTANT,
+            stop_sequence: (),
+            usage: {input_tokens: 10, output_tokens: 5},
+            content: [{'type: "text", text: "ok"}]
+        };
     }
 }

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -18,11 +18,15 @@ import ballerina/ai;
 import ballerina/test;
 
 const SERVICE_URL = "http://localhost:8080/llm/anthropic";
+const TEMP_TEST_SERVICE_URL = "http://localhost:7070/temptest/anthropic";
 const API_KEY = "not-a-real-api-key";
 const ERROR_MESSAGE = "Error occurred while attempting to parse the response from the LLM as the expected type. Retrying and/or validating the prompt could fix the response.";
 const RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE = "Runtime schema generation is not yet supported";
 
 final ModelProvider claudeProvider = check new (API_KEY, CLAUDE_3_7_SONNET_20250219, SERVICE_URL);
+final ModelProvider opus47TempProvider = check new (API_KEY, CLAUDE_OPUS_4_7, TEMP_TEST_SERVICE_URL);
+final ModelProvider opus48TempProvider = check new (API_KEY, CLAUDE_OPUS_4_8, TEMP_TEST_SERVICE_URL);
+final ModelProvider nonOpusTempProvider = check new (API_KEY, CLAUDE_3_7_SONNET_20250219, TEMP_TEST_SERVICE_URL);
 
 @test:Config
 function testGenerateMethodWithBasicReturnType() returns ai:Error? {
@@ -391,12 +395,28 @@ function testGenerateMethodWithTextChunk() returns error? {
 
 @test:Config
 function testModelInitializationWithOpus47() returns error? {
-    // This verifies that 'claude-opus-4-7' is now a recognized type in ANTHROPIC_MODEL_NAMES
     ModelProvider _ = check new (API_KEY, "claude-opus-4-7", SERVICE_URL);
 }
 
 @test:Config
 function testModelInitializationWithOpus48() returns error? {
-    // This verifies that 'claude-opus-4-8' is now a recognized type in ANTHROPIC_MODEL_NAMES
     ModelProvider _ = check new (API_KEY, "claude-opus-4-8", SERVICE_URL);
+}
+
+@test:Config
+function testOpus47ChatOmitsTemperature() returns error? {
+    ai:ChatAssistantMessage result = check opus47TempProvider->chat({role: ai:USER, content: "Hello"});
+    test:assertEquals(result.content, "ok");
+}
+
+@test:Config
+function testOpus48ChatOmitsTemperature() returns error? {
+    ai:ChatAssistantMessage result = check opus48TempProvider->chat({role: ai:USER, content: "Hello"});
+    test:assertEquals(result.content, "ok");
+}
+
+@test:Config
+function testNonOpusChatIncludesTemperature() returns error? {
+    ai:ChatAssistantMessage result = check nonOpusTempProvider->chat({role: ai:USER, content: "Hello"});
+    test:assertEquals(result.content, "ok");
 }

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -277,7 +277,7 @@ function testGenerateMethodWithInvalidRecordType() returns ai:Error? {
     string msg = (<error>rating).message();
     test:assertTrue(rating is error);
     test:assertTrue(msg.includes(RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE),
-        string `expected error message to contain: ${RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE}, but found ${msg}`);
+            string `expected error message to contain: ${RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE}, but found ${msg}`);
 }
 
 type ProductNameArray ProductName[];
@@ -356,7 +356,6 @@ function testGenerateMethodWithArrayUnionBasicType() returns error? {
     test:assertTrue(result is Cricketers3[]);
 }
 
-
 @test:Config
 function testGenerateMethodWithArrayUnionNull() returns error? {
     Cricketers4[]? result = check claudeProvider->generate(`Name 10 world class cricketers`);
@@ -371,11 +370,11 @@ function testGenerateMethodWithArrayUnionRecord() returns ai:Error? {
 
 @test:Config
 function testGenerateMethodWithArrayUnionRecord2() returns ai:Error? {
-   Cricketers7[]|Cricketers8|error result = claudeProvider->generate(`Name a random world class cricketer`);
+    Cricketers7[]|Cricketers8|error result = claudeProvider->generate(`Name a random world class cricketer`);
     test:assertTrue(result is Cricketers8);
 }
 
- @test:Config
+@test:Config
 function testGenerateMethodWithTextChunk() returns error? {
     ai:TextChunk chunk = {
         content: string `Title: ${blog1.title} Content: ${blog1.content}`
@@ -388,4 +387,16 @@ function testGenerateMethodWithTextChunk() returns error? {
 
     ReviewArray result = check claudeProvider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
     test:assertEquals(result, [review, review]);
+}
+
+@test:Config
+function testModelInitializationWithOpus47() returns error? {
+    // This verifies that 'claude-opus-4-7' is now a recognized type in ANTHROPIC_MODEL_NAMES
+    ModelProvider _ = check new (API_KEY, "claude-opus-4-7", SERVICE_URL);
+}
+
+@test:Config
+function testModelInitializationWithOpus48() returns error? {
+    // This verifies that 'claude-opus-4-8' is now a recognized type in ANTHROPIC_MODEL_NAMES
+    ModelProvider _ = check new (API_KEY, "claude-opus-4-8", SERVICE_URL);
 }

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -87,6 +87,8 @@ public enum ANTHROPIC_MODEL_NAMES {
     CLAUDE_OPUS_4_5 = "claude-opus-4-5",
     CLAUDE_OPUS_4_5_20251101 = "claude-opus-4-5-20251101",
     CLAUDE_OPUS_4_6 = "claude-opus-4-6",
+    CLAUDE_OPUS_4_7 = "claude-opus-4-7",
+    CLAUDE_OPUS_4_8 = "claude-opus-4-8",
     CLAUDE_SONNET_4_6 = "claude-sonnet-4-6",
     CLAUDE_OPUS_4_1_20250805 = "claude-opus-4-1-20250805",
     CLAUDE_OPUS_4_20250514 = "claude-opus-4-20250514",


### PR DESCRIPTION
## Purpose
This PR introduces support for Anthropic's newer reasoning models, specifically Claude Opus 4.7 and 4.8 (`claude-opus-4-7` and `claude-opus-4-8`). 

Key changes include:
* Added `CLAUDE_OPUS_4_7` and `CLAUDE_OPUS_4_8` to the `ANTHROPIC_MODEL_NAMES` enum.
* Updated `ModelProvider` and `provider_utils` to conditionally exclude the `temperature` parameter from the API request payload when using these models. This prevents a `400 Bad Request` error, as these models utilize internal dynamic sampling and have deprecated external temperature controls.
* Added new test cases (`testModelInitializationWithOpus47` and `testModelInitializationWithOpus48`) to verify correct initialization of the new models.
* Minor formatting and assertion cleanups in existing test files.

Fixes: Issue 1612

## Examples
Initializing the provider with the newly supported reasoning models:
```ballerina
ModelProvider opus47Provider = check new (API_KEY, "claude-opus-4-7", SERVICE_URL);
ModelProvider opus48Provider = check new (API_KEY, "claude-opus-4-8", SERVICE_URL);


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds support for Anthropic Claude Opus 4.7 and 4.8 to the Ballerina Anthropic AI module and updates request handling and tests to accommodate model-specific behavior.

Changes
- Model support: Added CLAUDE_OPUS_4_7 and CLAUDE_OPUS_4_8 to the ANTHROPIC_MODEL_NAMES enum so providers can be initialized with the new models.
- API request handling: Introduced a supportsTemperature helper and updated ModelProvider.chat and provider_utils.generateLlmResponse to omit the temperature field for the Opus 4.7/4.8 models. This prevents invalid requests for models that use internal sampling and do not accept external temperature.
- Tests and test service: Added unit tests verifying provider initialization for the new models and that requests to Opus 4.7/4.8 omit temperature; extended the test HTTP service to assert temperature handling. Minor assertion and formatting cleanups were applied in existing tests.
- Dependency updates: Ballerina dependency pins in Dependencies.toml updated (ai 1.11.1→1.11.2, http 2.14.10→2.14.11, io 1.8.0→1.8.1, mime 2.12.1→2.12.2, task 2.11.1→2.11.2).

Intent and outcome
- Enable use of the new Claude Opus 4.7 and 4.8 models without causing API errors.
- Improve request construction accuracy by making temperature inclusion model-aware.
- Validate behavior via tests to maintain reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->