### PR TITLE
Fix/anthropic multi round parallel tool calls

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},
@@ -118,7 +118,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -151,7 +151,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -369,7 +369,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -377,7 +377,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -191,32 +191,58 @@ public isolated client class ModelProvider {
             return anthropicMessages;
         }
 
+        map<json>[] pendingToolResults = [];
         foreach ai:ChatMessage message in messages {
+            if message is ai:ChatFunctionMessage {
+                pendingToolResults.push({
+                    'type: "tool_result",
+                    tool_use_id: message.id ?: message.name,
+                    content: message.content ?: ""
+                });
+                continue;
+            }
+
+            if pendingToolResults.length() > 0 {
+                anthropicMessages.push({role: ai:USER, content: pendingToolResults.clone()});
+                pendingToolResults = [];
+            }
+
             if message is ai:ChatUserMessage {
                 anthropicMessages.push({
                     role: ai:USER,
                     content: check getChatMessageStringContent(message.content)
                 });
             } else if message is ai:ChatSystemMessage {
-                // Add a user message containing the system prompt
                 string content = check getChatMessageStringContent(message.content);
                 anthropicMessages.push({
                     role: ai:USER,
                     content: string `<system>${content}</system>\n\n`
                 });
-            } else if message is ai:ChatAssistantMessage && message.content is string {
-                anthropicMessages.push({
-                    role: ai:ASSISTANT,
-                    content: message.content ?: ""
-                });
-            } else if message is ai:ChatFunctionMessage && message.content is string {
-                // Include function results as user messages with special formatting
-                anthropicMessages.push({
-                    role: ai:USER,
-                    content: string `<function_results>\nFunction: ${message.name}\n`
-                        + string `Output: ${message.content ?: ""}\n</function_results>`
-                });
+            } else if message is ai:ChatAssistantMessage {
+                map<json>[] contentBlocks = [];
+                string? textContent = message.content;
+                if textContent is string {
+                    contentBlocks.push({'type: "text", text: textContent});
+                }
+                ai:FunctionCall[]? toolCalls = message.toolCalls;
+                if toolCalls is ai:FunctionCall[] {
+                    foreach ai:FunctionCall tc in toolCalls {
+                        contentBlocks.push({
+                            'type: "tool_use",
+                            id: tc.id ?: "",
+                            name: tc.name,
+                            input: tc.arguments ?: {}
+                        });
+                    }
+                }
+                if contentBlocks.length() > 0 {
+                    anthropicMessages.push({role: ai:ASSISTANT, content: contentBlocks});
+                }
             }
+        }
+
+        if pendingToolResults.length() > 0 {
+            anthropicMessages.push({role: ai:USER, content: pendingToolResults});
         }
         return anthropicMessages;
     }
@@ -255,7 +281,7 @@ isolated function mapContentToFunctionCall(ContentBlock block) returns ai:Functi
     if arguments is error {
         return error ai:LlmError("Invalid or malformed arguments received in function call response.", arguments);
     }
-    return {name: blockName, arguments};
+    return {name: blockName, arguments, id: block.id};
 }
 
 isolated function getChatMessageStringContent(ai:Prompt|string prompt) returns string|ai:Error {

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -191,11 +191,10 @@ public isolated client class ModelProvider {
             return anthropicMessages;
         }
 
-        map<json>[] pendingToolResults = [];
+        ToolResultContentBlock[] pendingToolResults = [];
         foreach ai:ChatMessage message in messages {
             if message is ai:ChatFunctionMessage {
                 pendingToolResults.push({
-                    'type: "tool_result",
                     tool_use_id: message.id ?: message.name,
                     content: message.content ?: ""
                 });
@@ -219,17 +218,16 @@ public isolated client class ModelProvider {
                     content: string `<system>${content}</system>\n\n`
                 });
             } else if message is ai:ChatAssistantMessage {
-                map<json>[] contentBlocks = [];
+                RequestContentBlock[] contentBlocks = [];
                 string? textContent = message.content;
                 if textContent is string {
-                    contentBlocks.push({'type: "text", text: textContent});
+                    contentBlocks.push(<TextContentBlock>{text: textContent});
                 }
                 ai:FunctionCall[]? toolCalls = message.toolCalls;
                 if toolCalls is ai:FunctionCall[] {
                     foreach ai:FunctionCall tc in toolCalls {
-                        contentBlocks.push({
-                            'type: "tool_use",
-                            id: tc.id ?: "",
+                        contentBlocks.push(<ToolUseContentBlock>{
+                            id: tc.id ?: tc.name,
                             name: tc.name,
                             input: tc.arguments ?: {}
                         });

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/ai;
 import ballerina/http;
 import ballerina/test;
 
@@ -49,5 +50,70 @@ service /llm on new http:Listener(8080) {
         test:assertEquals(parameters, getExpectedParameterSchema(initialText),
                 string `Test failed for prompt with initial content, ${initialText}`);
         return getTestServiceResponse(initialText);
+    }
+}
+
+service /chattest on new http:Listener(9090) {
+    resource function post anthropic/messages(map<json> payload) returns AnthropicApiResponse|error {
+        json[] messages = check payload["messages"].ensureType();
+        test:assertEquals(messages.length(), 3, "Expected 3 messages in the serialized Anthropic payload");
+
+        // message[0]: user message — always a plain string for these tests
+        map<json> firstMsg = check messages[0].ensureType();
+        string firstContent = check firstMsg["content"].ensureType();
+
+        // message[1]: assistant must be serialized as a content block array, not a plain string
+        map<json> assistantMsg = check messages[1].ensureType();
+        test:assertEquals(assistantMsg["role"], "assistant");
+        json[] assistantContent = check assistantMsg["content"].ensureType();
+        map<json> toolUseBlock = check assistantContent[0].ensureType();
+        test:assertEquals(toolUseBlock["type"], "tool_use", "Assistant tool call must use 'tool_use' block");
+        test:assertEquals(toolUseBlock["id"], "toolu_001");
+
+        // message[2]: user message must carry tool_result blocks, never plain XML text
+        map<json> userMsg = check messages[2].ensureType();
+        test:assertEquals(userMsg["role"], "user");
+        json[] userContent = check userMsg["content"].ensureType();
+        map<json> firstResult = check userContent[0].ensureType();
+        test:assertEquals(firstResult["type"], "tool_result", "Tool result must be 'tool_result' block, not XML text");
+        test:assertEquals(firstResult["tool_use_id"], "toolu_001", "tool_use_id must match the original tool call id");
+
+        if firstContent == "Add 5 and 3, subtract 4 from 10" {
+            // Parallel test: assistant must have 2 tool_use blocks,
+            // and both results must be batched into a single user message
+            test:assertEquals(assistantContent.length(), 2, "Expected 2 tool_use blocks for parallel tool calls");
+            test:assertEquals(userContent.length(), 2, "Expected both parallel tool results in one user message");
+            map<json> secondResult = check userContent[1].ensureType();
+            test:assertEquals(secondResult["type"], "tool_result");
+            test:assertEquals(secondResult["tool_use_id"], "toolu_002");
+            test:assertEquals(firstResult["content"], "8");
+            test:assertEquals(secondResult["content"], "6");
+            return {
+                id: "parallel-test-id",
+                model: CLAUDE_3_7_SONNET_20250219,
+                'type: "message",
+                stop_reason: "end_turn",
+                role: ai:ASSISTANT,
+                stop_sequence: (),
+                usage: {input_tokens: 70, output_tokens: 15},
+                content: [{'type: "text", text: "The answers are 8 and 6."}]
+            };
+        }
+
+        // Multi-round test: single tool_use, single tool_result
+        test:assertEquals(assistantContent.length(), 1, "Expected 1 tool_use block");
+        test:assertEquals(userContent.length(), 1, "Expected 1 tool_result block");
+        test:assertEquals(toolUseBlock["name"], "add");
+        test:assertEquals(firstResult["content"], "8");
+        return {
+            id: "multi-round-test-id",
+            model: CLAUDE_3_7_SONNET_20250219,
+            'type: "message",
+            stop_reason: "end_turn",
+            role: ai:ASSISTANT,
+            stop_sequence: (),
+            usage: {input_tokens: 50, output_tokens: 10},
+            content: [{'type: "text", text: "The answer is 8."}]
+        };
     }
 }

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -53,7 +53,7 @@ service /llm on new http:Listener(8080) {
     }
 }
 
-service /chattest on new http:Listener(9090) {
+service /chat on new http:Listener(9090) {
     resource function post anthropic/messages(map<json> payload) returns AnthropicApiResponse|error {
         json[] messages = check payload["messages"].ensureType();
         test:assertEquals(messages.length(), 3, "Expected 3 messages in the serialized Anthropic payload");

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -18,7 +18,7 @@ import ballerina/ai;
 import ballerina/test;
 
 const SERVICE_URL = "http://localhost:8080/llm/anthropic";
-const CHAT_SERVICE_URL = "http://localhost:9090/chattest/anthropic";
+const CHAT_SERVICE_URL = "http://localhost:9090/chat/anthropic";
 const API_KEY = "not-a-real-api-key";
 const ERROR_MESSAGE = "Error occurred while attempting to parse the response from the LLM as the expected type. Retrying and/or validating the prompt could fix the response.";
 const RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE = "Runtime schema generation is not yet supported";

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -397,6 +397,7 @@ function testMultiRoundToolCallSerialization() returns error? {
     // Simulate the agent history after one round: user asked, assistant requested a tool, tool returned a result.
     // We call chat() with this pre-built history and verify the HTTP payload the code sends to Anthropic
     // has proper tool_use and tool_result blocks — not XML text.
+    ai:ChatFunctionMessage addResult = {role: "function", name: "add", id: "toolu_001", content: "8"};
     ai:ChatMessage[] history = [
         {role: ai:USER, content: "Add 5 and 3"},
         {
@@ -404,7 +405,7 @@ function testMultiRoundToolCallSerialization() returns error? {
             content: (),
             toolCalls: [{name: "add", id: "toolu_001", arguments: {a: 5, b: 3}}]
         },
-        {role: ai:FUNCTION, name: "add", id: "toolu_001", content: "8"}
+        addResult
     ];
 
     ai:ChatAssistantMessage result = check chatTestProvider->chat(history);
@@ -416,6 +417,8 @@ function testParallelToolCallSerialization() returns error? {
     // Simulate parallel tool calls: assistant requested two tools at once.
     // The two ChatFunctionMessages must be batched into a SINGLE user message
     // with two tool_result blocks — not two separate user messages.
+    ai:ChatFunctionMessage addResult = {role: "function", name: "add", id: "toolu_001", content: "8"};
+    ai:ChatFunctionMessage subtractResult = {role: "function", name: "subtract", id: "toolu_002", content: "6"};
     ai:ChatMessage[] history = [
         {role: ai:USER, content: "Add 5 and 3, subtract 4 from 10"},
         {
@@ -426,8 +429,8 @@ function testParallelToolCallSerialization() returns error? {
                 {name: "subtract", id: "toolu_002", arguments: {a: 10, b: 4}}
             ]
         },
-        {role: ai:FUNCTION, name: "add", id: "toolu_001", content: "8"},
-        {role: ai:FUNCTION, name: "subtract", id: "toolu_002", content: "6"}
+        addResult,
+        subtractResult
     ];
 
     ai:ChatAssistantMessage result = check chatTestProvider->chat(history);

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -18,11 +18,13 @@ import ballerina/ai;
 import ballerina/test;
 
 const SERVICE_URL = "http://localhost:8080/llm/anthropic";
+const CHAT_SERVICE_URL = "http://localhost:9090/chattest/anthropic";
 const API_KEY = "not-a-real-api-key";
 const ERROR_MESSAGE = "Error occurred while attempting to parse the response from the LLM as the expected type. Retrying and/or validating the prompt could fix the response.";
 const RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE = "Runtime schema generation is not yet supported";
 
 final ModelProvider claudeProvider = check new (API_KEY, CLAUDE_3_7_SONNET_20250219, SERVICE_URL);
+final ModelProvider chatTestProvider = check new (API_KEY, CLAUDE_3_7_SONNET_20250219, CHAT_SERVICE_URL);
 
 @test:Config
 function testGenerateMethodWithBasicReturnType() returns ai:Error? {
@@ -388,4 +390,46 @@ function testGenerateMethodWithTextChunk() returns error? {
 
     ReviewArray result = check claudeProvider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
     test:assertEquals(result, [review, review]);
+}
+
+@test:Config
+function testMultiRoundToolCallSerialization() returns error? {
+    // Simulate the agent history after one round: user asked, assistant requested a tool, tool returned a result.
+    // We call chat() with this pre-built history and verify the HTTP payload the code sends to Anthropic
+    // has proper tool_use and tool_result blocks — not XML text.
+    ai:ChatMessage[] history = [
+        {role: ai:USER, content: "Add 5 and 3"},
+        {
+            role: ai:ASSISTANT,
+            content: (),
+            toolCalls: [{name: "add", id: "toolu_001", arguments: {a: 5, b: 3}}]
+        },
+        {role: ai:FUNCTION, name: "add", id: "toolu_001", content: "8"}
+    ];
+
+    ai:ChatAssistantMessage result = check chatTestProvider->chat(history);
+    test:assertEquals(result.content, "The answer is 8.");
+}
+
+@test:Config
+function testParallelToolCallSerialization() returns error? {
+    // Simulate parallel tool calls: assistant requested two tools at once.
+    // The two ChatFunctionMessages must be batched into a SINGLE user message
+    // with two tool_result blocks — not two separate user messages.
+    ai:ChatMessage[] history = [
+        {role: ai:USER, content: "Add 5 and 3, subtract 4 from 10"},
+        {
+            role: ai:ASSISTANT,
+            content: (),
+            toolCalls: [
+                {name: "add", id: "toolu_001", arguments: {a: 5, b: 3}},
+                {name: "subtract", id: "toolu_002", arguments: {a: 10, b: 4}}
+            ]
+        },
+        {role: ai:FUNCTION, name: "add", id: "toolu_001", content: "8"},
+        {role: ai:FUNCTION, name: "subtract", id: "toolu_002", content: "6"}
+    ];
+
+    ai:ChatAssistantMessage result = check chatTestProvider->chat(history);
+    test:assertEquals(result.content, "The answers are 8 and 6.");
 }

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -104,8 +104,8 @@ public enum ANTHROPIC_MODEL_NAMES {
 type AnthropicMessage record {|
     # Role of the participant in the conversation (e.g., "user" or "assistant")
     string role;
-    # The message content
-    string content;
+    # The message content — either plain text or an array of content blocks
+    json content;
 |};
 
 # Anthropic API response format

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -100,12 +100,45 @@ public enum ANTHROPIC_MODEL_NAMES {
     CLAUDE_3_HAIKU_20240307 = "claude-3-haiku-20240307"
 }
 
+# A text content block in an Anthropic request message
+type TextContentBlock record {|
+    # The type discriminator for a text block
+    "text" 'type = "text";
+    # The text content
+    string text;
+|};
+
+# A tool-use content block in an assistant request message
+type ToolUseContentBlock record {|
+    # The type discriminator for a tool-use block
+    "tool_use" 'type = "tool_use";
+    # The unique identifier of the tool call, used to correlate the result
+    string id;
+    # Name of the tool being invoked
+    string name;
+    # Input arguments passed to the tool
+    json input;
+|};
+
+# A tool-result content block in a user request message
+type ToolResultContentBlock record {|
+    # The type discriminator for a tool-result block
+    "tool_result" 'type = "tool_result";
+    # The id of the `tool_use` block this result corresponds to
+    string tool_use_id;
+    # The result content returned by the tool
+    json content;
+|};
+
+# Any content block that can appear in an Anthropic request message
+type RequestContentBlock TextContentBlock|ToolUseContentBlock|ToolResultContentBlock;
+
 # Anthropic API request message format
 type AnthropicMessage record {|
     # Role of the participant in the conversation (e.g., "user" or "assistant")
     string role;
     # The message content — either plain text or an array of content blocks
-    json content;
+    string|RequestContentBlock[] content;
 |};
 
 # Anthropic API response format


### PR DESCRIPTION
## Purpose

Fixes multi-round and parallel tool call serialization for the Anthropic API.

Previously, agents using the Anthropic provider failed with a
"Maximum iteration limit exceeded" error on any prompt requiring more than
one tool call round. The root cause was a set of serialization bugs in
`mapToAnthropicMessages` that corrupted the conversation history before it
was sent to the Anthropic Messages API.

Fixes https://github.com/wso2/product-integrator/issues/1647

### Bugs fixed

- **Assistant tool-call messages silently dropped** — the condition
  `message.content is string` evaluated to `false` when the assistant
  responded with tool calls (`content` is `null`, `toolCalls` is set),
  causing those messages to be omitted from history. Anthropic never saw
  the prior tool call, so it re-requested the same tool forever.

- **Tool results sent as XML text** — `ChatFunctionMessage` results were
  wrapped in `<function_results>…</function_results>` plain text. Anthropic
  does not parse this as a tool output. Results are now sent as structured
  `tool_result` content blocks with the correct `tool_use_id`.

- **Tool call `id` dropped** — `mapContentToFunctionCall` discarded
  `block.id` from the response, making it impossible to correlate a
  `tool_result` back to its `tool_use`. The `id` is now preserved on
  `ai:FunctionCall`.

- **`AnthropicMessage.content` accepted only `string`** — the type blocked
  sending structured content block arrays. Changed to `json` to support
  both plain strings and content block arrays.

- **Parallel tool results not batched** — consecutive `ChatFunctionMessage`
  entries were each serialised into their own user message. Anthropic
  requires all results from a single parallel round to be in one user
  message. A `pendingToolResults` accumulator now batches them correctly.

## Examples

An agent performing chained arithmetic now completes successfully:

```ballerina
ai:Agent agent = check new (
    model = check new anthropic:ModelProvider(apiKey, CLAUDE_HAIKU_4_5),
    tools = [add, subtract, multiply],
    systemPrompt = {role: "Math Assistant", instructions: "Use tools for all calculations."}
);

string result = check agent.run("What is (5 + 3) * (10 - 4)?");
// Before fix: error — Maximum iteration limit exceeded
// After fix:  "The result is 48."



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request fixes Anthropic chat message serialization for tool-calling so multi-round and parallel tool invocations are represented correctly in the outbound API payload. This restores stable conversation flow for Anthropic agents and prevents failures caused by corrupted tool-call/function-result history.

## Key Changes

- **Core fix in `mapToAnthropicMessages` (`ballerina/model-provider.bal`):**
  - Preserve assistant tool-call messages by serializing tool calls as structured **`tool_use`** content blocks (including the original tool-call IDs).
  - Serialize function/tool results as structured **`tool_result`** content blocks instead of XML-wrapped text.
  - Buffer consecutive tool results and flush them as a single **user** message containing an array of `tool_result` blocks, enabling correct batching for **parallel** tool calls.
  - Ensure remaining buffered tool results are flushed at the end to complete multi-round sequences.

- **Tool-call ID correlation (`mapContentToFunctionCall`):**
  - Include Anthropic content-block **id** when returning mapped `ai:FunctionCall` objects to maintain correlation between `tool_use` and `tool_result`.

- **Structured request content support (`ballerina/types.bal`):**
  - Extend the Anthropic request message model so `AnthropicMessage.content` can be either plain text (`string`) or an array of typed content blocks (`RequestContentBlock[]`), covering `text` and `tool_use`/`tool_result` variants.

- **Dependency updates:**
  - Update auto-generated Ballerina dependency versions in `ballerina/Dependencies.toml` for compatibility with the updated code.

## Test Coverage

- Added a dedicated test HTTP service in `ballerina/tests/test_services.bal` (`POST /chat/anthropic/messages`) that validates the exact serialized `messages` structure:
  - Confirms assistant messages contain `tool_use` blocks with matching IDs.
  - Confirms user messages contain `tool_result` blocks with matching `tool_use_id`.
  - Verifies both **multi-round** (single tool call/result) and **parallel** (two tool calls/results batched into one user message) scenarios.

- Added/updated test cases in `ballerina/tests/tests.bal` to assert expected provider behavior for both serialization modes.

## Outcome

Anthropic agents can now complete prompts requiring multiple tool-call rounds and parallel tool invocations with correctly correlated tool-call history, improving reliability and restoring expected tool-calling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->