### PR TITLE
Fix/remove retired anthropic models

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.anthropic"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.anthropic"
-version = "1.3.4"
+version = "1.3.5"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.anthropic-native"
-version = "1.3.4"
-path = "../native/build/libs/ai.anthropic-native-1.3.4.jar"
+version = "1.3.5"
+path = "../native/build/libs/ai.anthropic-native-1.3.5-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-anthropic-compiler-plugin"
 class = "io.ballerina.lib.ai.anthropic.AiAnthropicCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.anthropic-compiler-plugin-1.3.4.jar"
+path = "../compiler-plugin/build/libs/ai.anthropic-compiler-plugin-1.3.5-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -408,7 +408,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.anthropic"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -38,7 +38,7 @@ Here's how to initialize the Model Provider:
 import ballerina/ai;
 import ballerinax/ai.anthropic;
 
-final ai:ModelProvider anthropicModel = check new anthropic:ModelProvider("anthropicAiApiKey", anthropic:CLAUDE_3_7_SONNET_20250219, "2023-06-01");
+final ai:ModelProvider anthropicModel = check new anthropic:ModelProvider("anthropicAiApiKey", anthropic:CLAUDE_SONNET_4_6, "2023-06-01");
 ```
 
 ### Step 4: Invoke chat completion

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -130,7 +130,7 @@ public isolated client class ModelProvider {
 
         AnthropicApiResponse|error anthropicResponse = self.AnthropicClient->/messages.post(requestPayload, headers);
         if anthropicResponse is error {
-            ai:Error err = error ai:LlmInvalidResponseError("Unexpected response format from Anthropic API", anthropicResponse);
+            ai:Error err = createLlmErrorFromHttpError(anthropicResponse);
             span.close(err);
             return err;
         }

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -331,7 +331,7 @@ isolated function generateLlmResponse(http:Client anthropicClient, string apiKey
 
     AnthropicApiResponse|error response = anthropicClient->/messages.post(request, headers);
     if response is error {
-        ai:Error err = error("LLM call failed: ", response);
+        ai:Error err = createLlmErrorFromHttpError(response);
         span.close(err);
         return err;
     }
@@ -381,6 +381,16 @@ isolated function generateLlmResponse(http:Client anthropicClient, string apiKey
     span.addOutputType(observe:JSON);
     span.close();
     return result;
+}
+
+isolated function createLlmErrorFromHttpError(error httpError) returns ai:Error {
+    if httpError is http:ApplicationResponseError {
+        http:Detail detail = httpError.detail();
+        return error ai:LlmInvalidResponseError(
+            string `Anthropic API request failed with status ${detail.statusCode}: ${detail.body.toString()}`,
+            httpError);
+    }
+    return error ai:LlmInvalidResponseError("Unexpected response format from Anthropic API", httpError);
 }
 
 isolated function getFunctionCallFromContentBlocks(ContentBlock[] blocks) returns ai:FunctionCall[]|ai:Error {

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -19,7 +19,7 @@ import ballerina/test;
 
 service /llm on new http:Listener(8080) {
     resource function post anthropic/messages(map<json> payload)returns AnthropicApiResponse|error {
-        test:assertEquals(payload["model"], CLAUDE_3_7_SONNET_20250219);
+        test:assertEquals(payload["model"], CLAUDE_SONNET_4_6);
         test:assertEquals(payload["max_tokens"], 512);
         test:assertEquals(payload["temperature"], 0.7d);
 

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -570,7 +570,7 @@ isolated function getExpectedContentParts(string message) returns (map<anydata>)
 isolated function getTestServiceResponse(string content) returns AnthropicApiResponse =>
     {
     id: "test-id",
-    model: CLAUDE_3_7_SONNET_20250219,
+    model: CLAUDE_SONNET_4_6,
     'type: "message",
     stop_reason: "tool_calls",
     role: ai:ASSISTANT,

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -22,7 +22,7 @@ const API_KEY = "not-a-real-api-key";
 const ERROR_MESSAGE = "Error occurred while attempting to parse the response from the LLM as the expected type. Retrying and/or validating the prompt could fix the response.";
 const RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE = "Runtime schema generation is not yet supported";
 
-final ModelProvider claudeProvider = check new (API_KEY, CLAUDE_3_7_SONNET_20250219, SERVICE_URL);
+final ModelProvider claudeProvider = check new (API_KEY, CLAUDE_SONNET_4_6, SERVICE_URL);
 
 @test:Config
 function testGenerateMethodWithBasicReturnType() returns ai:Error? {

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -87,17 +87,7 @@ public enum ANTHROPIC_MODEL_NAMES {
     CLAUDE_OPUS_4_5 = "claude-opus-4-5",
     CLAUDE_OPUS_4_5_20251101 = "claude-opus-4-5-20251101",
     CLAUDE_OPUS_4_6 = "claude-opus-4-6",
-    CLAUDE_SONNET_4_6 = "claude-sonnet-4-6",
-    CLAUDE_OPUS_4_1_20250805 = "claude-opus-4-1-20250805",
-    CLAUDE_OPUS_4_20250514 = "claude-opus-4-20250514",
-    CLAUDE_SONNET_4_20250514 = "claude-sonnet-4-20250514",
-    CLAUDE_3_7_SONNET_20250219 = "claude-3-7-sonnet-20250219",
-    CLAUDE_3_5_HAIKU_20241022 = "claude-3-5-haiku-20241022",
-    CLAUDE_3_5_SONNET_20241022 = "claude-3-5-sonnet-20241022",
-    CLAUDE_3_5_SONNET_20240620 = "claude-3-5-sonnet-20240620",
-    CLAUDE_3_OPUS_20240229 = "claude-3-opus-20240229",
-    CLAUDE_3_SONNET_20240229 = "claude-3-sonnet-20240229",
-    CLAUDE_3_HAIKU_20240307 = "claude-3-haiku-20240307"
+    CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
 }
 
 # Anthropic API request message format

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -78,6 +78,12 @@ public type ConnectionConfig record {|
 |};
 
 # Models types for Anthropic
+#
+# Retired models (`CLAUDE_3_SONNET_20240229`, `CLAUDE_3_5_SONNET_20240620`, `CLAUDE_3_5_SONNET_20241022`,
+# `CLAUDE_3_OPUS_20240229`, `CLAUDE_3_5_HAIKU_20241022`, `CLAUDE_3_7_SONNET_20250219`, `CLAUDE_3_HAIKU_20240307`,
+# `CLAUDE_OPUS_4_20250514`, `CLAUDE_SONNET_4_20250514`, `CLAUDE_OPUS_4_1_20250805`) have been removed, as
+# Anthropic no longer serves requests for them. See the official deprecation list:
+# https://platform.claude.com/docs/en/about-claude/model-deprecations
 @display {label: "Anthropic Model Names"}
 public enum ANTHROPIC_MODEL_NAMES {
     CLAUDE_SONNET_4_5 = "claude-sonnet-4-5",


### PR DESCRIPTION
## Purpose

model->chat() and model->generate() fail with an opaque "Unexpected response format from Anthropic API" error whenever the underlying Anthropic API request itself fails (bad request, invalid/retired model, etc.). This makes it impossible to tell what actually went wrong.

Investigating [wso2/product-integrator#1696](https://github.com/wso2/product-integrator/issues/1696) (reported against CLAUDE_3_7_SONNET_20250219) traced the real cause: that model, along with 9 others still listed in ANTHROPIC_MODEL_NAMES, has been retired by Anthropic ([official deprecation list](https://platform.claude.com/docs/en/about-claude/model-deprecations)) and now always returns an error response — but the connector swallowed Anthropic's actual error body and replaced it with a generic, misleading message.

This PR:

- Removes the 10 retired model constants from ANTHROPIC_MODEL_NAMES, with a doc comment pointing to Anthropic's deprecation page.
- Adds createLlmErrorFromHttpError(), which unwraps http:ApplicationResponseError to surface Anthropic's real HTTP status code and response body instead of a generic string. Wired into both chat() and generate().
- Updates the README example and tests that referenced the now-removed CLAUDE_3_7_SONNET_20250219 to use CLAUDE_SONNET_4_6.

Fixes:

Fixes wso2/product-integrator#1696

## Examples

Before: error: Unexpected response format from Anthropic API

After: error: Anthropic API request failed with status 404: {"type":"error","error":{"type":"not_found_error","message":"model: claude-3-7-sonnet-20250219"}}

## Checklist
- [X] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [X] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed 10 retired Anthropic model constants and added Anthropic deprecation documentation.
- Updated examples and tests to use `CLAUDE_SONNET_4_6`.
- Improved Anthropic API error handling by exposing the HTTP status and response body through `createLlmErrorFromHttpError()`.
- Updated package and compiler plugin dependencies from `1.3.4` to `1.3.5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->